### PR TITLE
feat: implementa módulo de envio de e-mail para suporte Descrição:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/typeorm": "^11.0.0",
         "bcrypt": "^5.1.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.10.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.14.1",
@@ -8751,6 +8752,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^5.1.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.10.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.14.1",

--- a/src/application/email/dtos/send-email.dto.ts
+++ b/src/application/email/dtos/send-email.dto.ts
@@ -1,0 +1,6 @@
+export class SendEmailDto {
+    nome: string;
+    email: string;
+    assunto: string;
+    mensagem: string;
+  }

--- a/src/application/email/use-cases/email.service.ts
+++ b/src/application/email/use-cases/email.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+import { SendEmailDto } from '../dtos/send-email.dto';
+
+@Injectable()
+export class EmailService {
+  async enviarEmail(dto: SendEmailDto): Promise<{ message: string }> {
+    const { nome, email, assunto, mensagem } = dto;
+
+    if (!process.env.EMAIL_SUPPORT_USER || !process.env.EMAIL_SUPPORT_PASS || !process.env.EMAIL_SUPPORT_DESTINATION) {
+      throw new InternalServerErrorException('Configurações de e-mail não definidas.');
+    }
+
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.gmail.com',
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.EMAIL_SUPPORT_USER,
+        pass: process.env.EMAIL_SUPPORT_PASS,
+      },
+    });
+
+    await transporter.verify();
+
+    await transporter.sendMail({
+      from: `${nome} <${process.env.EMAIL_SUPPORT_USER}>`,
+      replyTo: email,
+      to: process.env.EMAIL_SUPPORT_DESTINATION,
+      subject: `Contato - ${assunto}`,
+      text: `Mensagem de: ${nome} <${email}>\n\n${mensagem}`,
+    });
+
+    return { message: 'E-mail enviado com sucesso!' };
+  }
+}

--- a/src/interfaces/http/email/email.controller.ts
+++ b/src/interfaces/http/email/email.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { SendEmailDto } from '../../../application/email/dtos/send-email.dto';
+import { EmailService } from '../../../application/email/use-cases/email.service';
+
+@Controller('email')
+export class EmailController {
+  constructor(private readonly service: EmailService) {}
+
+  @Post('suporte')
+  async enviarEmail(@Body() dto: SendEmailDto) {
+    return this.service.enviarEmail(dto);
+  }
+}

--- a/src/interfaces/http/email/email.module.ts
+++ b/src/interfaces/http/email/email.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EmailController } from './email.controller';
+import { EmailService } from '../../../application/email/use-cases/email.service';
+
+@Module({
+  controllers: [EmailController],
+  providers: [EmailService],
+})
+export class EmailModule {}


### PR DESCRIPTION
Este PR adiciona a funcionalidade completa de envio de e-mails de suporte na aplicação. A implementação inclui:
DTO SendEmailDto para padronizar os dados da requisição.
Serviço EmailService com integração ao Nodemailer.
Controller EmailController com rota POST /email/suporte.
Módulo EmailModule e sua importação no AppModule.