### PR TITLE
feat: implementação completa do dashboard no perfil do usuário

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+services:
+  db:
+    image: postgres:16
+    container_name: softsolutions_db
+    restart: always
+    environment:
+      POSTGRES_DB: dev_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+  api:
+    image: softsolutionsfatecvotorantim/backend:latest  # SEU NOME DA IMAGEM AQUI, minúsculo
+    container_name: softsolutions_api
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/dev_db
+      NODE_ENV: production
+    ports:
+      - "4000:4000"
+
+volumes:
+  pg_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-softsolutions",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-softsolutions",
-      "version": "0.3.0",
+      "version": "0.6.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-softsolutions",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-softsolutions",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-softsolutions",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/application/application.module.ts
+++ b/src/application/application.module.ts
@@ -62,6 +62,9 @@ import { EmitirCertificadoUseCase } from './use-cases/certificado/emitir-certifi
 import { CriarAvaliacaoUseCase } from './use-cases/avaliacao/criar-avaliacao.use-case';
 import { AtualizarAvaliacaoUseCase } from './use-cases/avaliacao/atualizar-avaliacao.use-case';
 
+// Dashboard use case
+import { BuildDashboardUseCase } from './use-cases/dashboard/build-dashboard.use-case';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -98,7 +101,10 @@ import { AtualizarAvaliacaoUseCase } from './use-cases/avaliacao/atualizar-avali
     EmitirCertificadoUseCase,
 
     // Avaliacao
-    CriarAvaliacaoUseCase, AtualizarAvaliacaoUseCase
+    CriarAvaliacaoUseCase, AtualizarAvaliacaoUseCase,
+
+    // Dashboard
+    BuildDashboardUseCase
   ],
   exports: [
     // Usuario
@@ -128,7 +134,10 @@ import { AtualizarAvaliacaoUseCase } from './use-cases/avaliacao/atualizar-avali
     EmitirCertificadoUseCase,
 
     // Avaliacao
-    CriarAvaliacaoUseCase, AtualizarAvaliacaoUseCase
+    CriarAvaliacaoUseCase, AtualizarAvaliacaoUseCase,
+
+    // Dashboard
+    BuildDashboardUseCase
   ],
 })
 export class ApplicationModule {}

--- a/src/application/use-cases/dashboard/build-dashboard.use-case.ts
+++ b/src/application/use-cases/dashboard/build-dashboard.use-case.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { DashboardResponseDto } from 'src/interfaces/http/dtos/responses/dashboard-response.dto';
+import { DashboardRepository } from 'src/infrastructure/database/repositories/dashboard.repository';
+
+@Injectable()
+export class BuildDashboardUseCase {
+  constructor(private readonly dashboardRepo: DashboardRepository) {}
+
+  async execute(usuarioId: number): Promise<DashboardResponseDto> {
+    return this.dashboardRepo.getDashboardData(usuarioId);
+  }
+}

--- a/src/infrastructure/database/repositories/certificado.repository.ts
+++ b/src/infrastructure/database/repositories/certificado.repository.ts
@@ -58,4 +58,12 @@ export class CertificadoRepository {
       relations: ['usuario', 'curso'],
     });
   }
+
+  async findAllByUsuario(id: number): Promise<CertificadoEntity[]> {
+  return this.repo.find({
+    where: { usuario: { id } },
+    relations: ['usuario', 'curso'],
+  });
+}
+
 }

--- a/src/infrastructure/database/repositories/dashboard.repository.ts
+++ b/src/infrastructure/database/repositories/dashboard.repository.ts
@@ -1,0 +1,166 @@
+import { Injectable } from '@nestjs/common';
+import { DashboardResponseDto } from 'src/interfaces/http/dtos/responses/dashboard-response.dto';
+import { InscricaoRepository } from './inscricao.repository';
+import { CertificadoRepository } from './certificado.repository';
+import { ProgressoAulaRepository } from './progresso-aula.repository';
+import { CursoRepository } from './curso.repository';
+import { AvaliacaoRepository } from './avaliacao.repository';
+
+@Injectable()
+export class DashboardRepository {
+  constructor(
+    private readonly inscricaoRepo: InscricaoRepository,
+    private readonly certificadoRepo: CertificadoRepository,
+    private readonly progressoRepo: ProgressoAulaRepository,
+    private readonly cursoRepo: CursoRepository,
+    private readonly avaliacaoRepo: AvaliacaoRepository,
+  ) {}
+
+  async getDashboardData(usuarioId: number): Promise<DashboardResponseDto> {
+    const inscricoes = await this.inscricaoRepo.findByUsuario(usuarioId);
+    const inscricoesAtivas = inscricoes.filter(i => i.status === 'ativo');
+    const certificados = await this.certificadoRepo.findAllByUsuario(usuarioId);
+
+    const progressoPorCurso = inscricoesAtivas.map((inscricao) => {
+      const cursoId = inscricao.curso?.id ?? 0;
+      const nomeCurso = inscricao.curso?.nomeCurso ?? '';
+      const totalAulas = inscricao.progressoAulas?.length ?? 0;
+      const concluidas = inscricao.progressoAulas?.filter((p) => p.concluida).length ?? 0;
+      const percentualConcluido = totalAulas > 0 ? Math.round((concluidas / totalAulas) * 100) : 0;
+
+      return { cursoId, nomeCurso, percentualConcluido };
+    });
+
+    const historicoEstudo = this.getHistoricoEstudo(inscricoes);
+    const diasAtivosEstudo = historicoEstudo.length;
+    const ultimoDiaAtividade = diasAtivosEstudo > 0
+      ? historicoEstudo[historicoEstudo.length - 1].data
+      : null;
+
+    const datas = historicoEstudo.map(h => h.data);
+    const diasConsecutivosEstudo = this.getDiasConsecutivos(datas);
+    const sequenciaAtualDiasConsecutivos = this.getSequenciaAtualConsecutiva(datas);
+
+    const cursosPorCategoria = this.getCursosPorCategoria(inscricoesAtivas);
+    const notasMediasPorCurso = await this.getNotasMedias(inscricoes);
+    const tempoTotalEstudoMinutos = this.getTempoTotalEstudado(inscricoes);
+    const avaliacoes = await this.getAvaliacoesPorUsuario(usuarioId, inscricoes);
+
+    return {
+      totalCursosInscritos: inscricoesAtivas.length,
+      totalCertificados: certificados.length,
+      progressoPorCurso,
+      historicoEstudo,
+      cursosPorCategoria,
+      notasMediasPorCurso,
+      tempoTotalEstudoMinutos,
+      avaliacoes,
+      diasAtivosEstudo,
+      ultimoDiaAtividade,
+      diasConsecutivosEstudo,
+      sequenciaAtualDiasConsecutivos,
+    };
+  }
+
+  private getHistoricoEstudo(inscricoes: any[]) {
+    const progresso = inscricoes.flatMap((i) => i?.progressoAulas ?? []);
+    const agrupado = progresso
+      .filter((p) => p?.dataConclusao)
+      .reduce((acc, p) => {
+        const data = p.dataConclusao?.toISOString().split('T')[0] ?? '';
+        acc[data] = (acc[data] || 0) + (p?.aula?.tempoAula ?? 0);
+        return acc;
+      }, {} as Record<string, number>);
+
+    return Object.entries(agrupado)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([data, minutosEstudados]) => ({
+        data,
+        minutosEstudados: Number(minutosEstudados),
+      }));
+  }
+
+  private getDiasConsecutivos(datas: string[]): number {
+    if (datas.length === 0) return 0;
+
+    const dias = datas.map(d => new Date(d)).sort((a, b) => a.getTime() - b.getTime());
+    let streak = 1;
+    let maxStreak = 1;
+
+    for (let i = 1; i < dias.length; i++) {
+      const diff = (dias[i].getTime() - dias[i - 1].getTime()) / (1000 * 60 * 60 * 24);
+      if (diff === 1) {
+        streak++;
+        maxStreak = Math.max(maxStreak, streak);
+      } else if (diff > 1) {
+        streak = 1;
+      }
+    }
+
+    return maxStreak;
+  }
+
+  private getSequenciaAtualConsecutiva(datas: string[]): number {
+    const diasEstudoSet = new Set(datas);
+    let hoje = new Date();
+    let contador = 0;
+
+    while (true) {
+      const dataStr = hoje.toISOString().split('T')[0];
+      if (diasEstudoSet.has(dataStr)) {
+        contador++;
+        hoje.setDate(hoje.getDate() - 1);
+      } else {
+        break;
+      }
+    }
+
+    return contador;
+  }
+
+  private getCursosPorCategoria(inscricoes: any[]) {
+    const agrupado = inscricoes.reduce((acc, i) => {
+      const categoria = i?.curso?.categoria ?? 'Outros';
+      acc[categoria] = (acc[categoria] || 0) + 1;
+      return acc;
+    }, {} as Record<string, number>);
+
+    return Object.entries(agrupado).map(([categoria, total]) => ({
+      categoria,
+      total: Number(total),
+    }));
+  }
+
+  private async getNotasMedias(inscricoes: any[]) {
+    return Promise.all(
+      inscricoes.map(async (i) => {
+        const cursoId = i?.curso?.id ?? 0;
+        const nomeCurso = i?.curso?.nomeCurso ?? '';
+        const notaMedia = await this.avaliacaoRepo.getCourseAverage(cursoId);
+        return { cursoId, nomeCurso, notaMedia };
+      })
+    );
+  }
+
+  private getTempoTotalEstudado(inscricoes: any[]) {
+    const progresso = inscricoes.flatMap((i) => i?.progressoAulas ?? []);
+    return progresso
+      .filter((p) => p?.concluida && p?.aula?.tempoAula)
+      .reduce((soma, p) => soma + (p?.aula?.tempoAula ?? 0), 0);
+  }
+
+  private async getAvaliacoesPorUsuario(usuarioId: number, inscricoes: any[]) {
+    return Promise.all(
+      inscricoes.map(async (i) => {
+        const cursoId = i?.curso?.id ?? 0;
+        const nomeCurso = i?.curso?.nomeCurso ?? '';
+        const avaliacao = await this.avaliacaoRepo.findByUserAndCourse(usuarioId, cursoId);
+        return {
+          cursoId,
+          nomeCurso,
+          avaliacaoFeita: !!avaliacao,
+        };
+      })
+    );
+  }
+}

--- a/src/infrastructure/infrastructure.module.ts
+++ b/src/infrastructure/infrastructure.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+
 // Entities
 import { UsuarioEntity } from './database/entities/usuario.entity';
 import { CursoEntity } from './database/entities/curso.entity';
@@ -20,23 +21,24 @@ import { InscricaoRepository } from './database/repositories/inscricao.repositor
 import { ProgressoAulaRepository } from './database/repositories/progresso-aula.repository';
 import { CertificadoRepository } from './database/repositories/certificado.repository';
 import { AvaliacaoRepository } from './database/repositories/avaliacao.repository';
+import { DashboardRepository } from './database/repositories/dashboard.repository';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       UsuarioEntity, CursoEntity, ModuloEntity, AulaEntity,
-      InscricaoEntity, ProgressoAulaEntity, CertificadoEntity, AvaliacaoEntity
+      InscricaoEntity, ProgressoAulaEntity, CertificadoEntity, AvaliacaoEntity,
     ]),
   ],
   providers: [
     UsuarioRepository, CursoRepository, ModuloRepository,
     AulaRepository, InscricaoRepository, ProgressoAulaRepository,
-    CertificadoRepository, AvaliacaoRepository,
+    CertificadoRepository, AvaliacaoRepository, DashboardRepository
   ],
   exports: [
     UsuarioRepository, CursoRepository, ModuloRepository,
     AulaRepository, InscricaoRepository, ProgressoAulaRepository,
-    CertificadoRepository, AvaliacaoRepository,
+    CertificadoRepository, AvaliacaoRepository, DashboardRepository
   ],
 })
 export class InfrastructureModule {}

--- a/src/interfaces/http/controllers/dashboard.controller.ts
+++ b/src/interfaces/http/controllers/dashboard.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param, ParseIntPipe, Request, UnauthorizedException, UseGuards } from '@nestjs/common';
+import { BuildDashboardUseCase } from 'src/application/use-cases/dashboard/build-dashboard.use-case';
+import { DashboardResponseDto } from 'src/interfaces/http/dtos/responses/dashboard-response.dto';
+import { AuthGuard } from 'src/interfaces/http/guards/auth.guard';
+
+@Controller('usuarios')
+export class DashboardController {
+  constructor(private readonly buildDashboardUseCase: BuildDashboardUseCase) {}
+
+  @UseGuards(AuthGuard)
+  @Get(':id/dashboard')
+  async getDashboard(
+    @Param('id', ParseIntPipe) id: number,
+    @Request() req,
+  ): Promise<DashboardResponseDto> {
+    const usuarioIdDoToken = req.user.sub;
+    if (id !== usuarioIdDoToken) {
+      throw new UnauthorizedException('Você só pode acessar seu próprio dashboard.');
+    }
+
+    return this.buildDashboardUseCase.execute(usuarioIdDoToken);
+  }
+}

--- a/src/interfaces/http/dtos/responses/dashboard-response.dto.ts
+++ b/src/interfaces/http/dtos/responses/dashboard-response.dto.ts
@@ -1,0 +1,40 @@
+export class DashboardResponseDto {
+  totalCursosInscritos: number;
+
+  totalCertificados: number;
+
+  progressoPorCurso: {
+    cursoId: number;
+    nomeCurso: string;
+    percentualConcluido: number;
+  }[];
+
+  historicoEstudo: {
+    data: string;
+    minutosEstudados: number;
+  }[];
+
+  cursosPorCategoria: {
+    categoria: string;
+    total: number;
+  }[];
+
+  notasMediasPorCurso: {
+    cursoId: number;
+    nomeCurso: string;
+    notaMedia: number;
+  }[];
+
+  tempoTotalEstudoMinutos: number;
+
+  avaliacoes: {
+    cursoId: number;
+    nomeCurso: string;
+    avaliacaoFeita: boolean;
+  }[];
+
+  diasAtivosEstudo: number;
+  ultimoDiaAtividade: string | null;
+  diasConsecutivosEstudo: number;
+  sequenciaAtualDiasConsecutivos: number;
+}

--- a/src/interfaces/interfaces.module.ts
+++ b/src/interfaces/interfaces.module.ts
@@ -10,6 +10,8 @@ import { InscricaoController } from './http/controllers/inscricao.controller';
 import { EmailController } from './http/controllers/email.controller';
 import { CertificadoController } from './http/controllers/certificado.controller';
 import { AvaliacaoController } from './http/controllers/avaliacao.controller';
+import { DashboardController } from './http/controllers/dashboard.controller';
+
 
 @Module({
   imports: [InfrastructureModule, ApplicationModule],
@@ -22,6 +24,7 @@ import { AvaliacaoController } from './http/controllers/avaliacao.controller';
     EmailController,
     CertificadoController,
     AvaliacaoController,
+    DashboardController,
   ],
 })
 export class InterfacesModule {}

--- a/test/dashboard-testes.http
+++ b/test/dashboard-testes.http
@@ -1,0 +1,19 @@
+###########################################################
+#################### 🔐 VARIÁVEIS #########################
+###########################################################
+
+@baseUrl = http://localhost:4000
+@tokenAluno = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjIsImVtYWlsIjoibHVjYXNAdGVzdGUuY29tIiwidGlwbyI6ImFsdW5vIiwiaWF0IjoxNzUwODE1NTIwLCJleHAiOjE3NTA5MDE5MjB9.1Oc7D3_Xdf99IdSwpGFlD6sY7DXfKA-5JaH70mhNT64
+
+
+
+###########################################################
+#################### 📊 DASHBOARD - ALUNO #################
+###########################################################
+
+GET {{baseUrl}}/usuarios/2/dashboard
+Authorization: Bearer {{tokenAluno}}
+
+### 5. VER PROGRESSO DO CURSO (SUCESSO)
+GET {{baseUrl}}/inscricoes/21/progresso
+Authorization: Bearer {{tokenAluno}}

--- a/test/usuario-testes.http
+++ b/test/usuario-testes.http
@@ -43,7 +43,7 @@ POST {{baseUrl}}/usuarios/login
 Content-Type: application/json
 
 {
-  "email": "maria@teste.com",
+  "email": "lucas@teste.com",
   "senha": "123456"
 }
 


### PR DESCRIPTION
Implementação completa do dashboard de aprendizado no perfil do usuário, incluindo:

- Backend:
  - Novo endpoint `GET /usuarios/:id/dashboard` com autenticação.
  - Cálculo de:
    - Cursos inscritos (ativos)
    - Certificados emitidos
    - Progresso por curso
    - Tempo total de estudo
    - Histórico de estudo por dia
    - Dias ativos de estudo
    - Último dia de atividade
    - Dias consecutivos de estudo
    - Sequência atual de dias consecutivos
    - Cursos por categoria